### PR TITLE
Port to GDBus

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 ### Build Requirements
  - gir1.2-gtk-3.0
  - python3
- - python3-dbus
  - python3-distutils
  - [python3-distutils-extra](https://launchpad.net/python-distutils-extra)
  - python3-gi
@@ -23,7 +22,6 @@
 ### Runtime Requirements
  - chfn
  - python3-cairo
- - python3-dbus
  - python3-gi
  - python3-pexpect
 

--- a/mugshot/MugshotWindow.py
+++ b/mugshot/MugshotWindow.py
@@ -23,10 +23,9 @@ import os
 import shutil
 import subprocess
 
-import dbus
 import pexpect
 
-from gi.repository import Gtk, GdkPixbuf, GLib  # pylint: disable=E0611
+from gi.repository import Gio, Gtk, GdkPixbuf, GLib  # pylint: disable=E0611
 
 
 from mugshot_lib import Window, SudoDialog, AccountsServiceAdapter, helpers
@@ -466,14 +465,15 @@ class MugshotWindow(Window):
     def set_pidgin_buddyicon_dbus(self, filename=None):
         """Set the pidgin buddy icon via dbus."""
         logger.debug('Updating pidgin buddy icon via dbus')
-        bus = dbus.SessionBus()
-        obj = bus.get_object("im.pidgin.purple.PurpleService",
-                             "/im/pidgin/purple/PurpleObject")
-        purple = dbus.Interface(obj, "im.pidgin.purple.PurpleInterface")
+        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        purple = Gio.DBusProxy.new_sync(bus, Gio.DBusProxyFlags.NONE, None,
+                                        "im.pidgin.purple.PurpleService",
+                                        "/im/pidgin/purple/PurpleObject",
+                                        "im.pidgin.purple.PurpleInterface", None)
         # To make the change instantly visible, set the icon to none first.
-        purple.PurplePrefsSetPath('/pidgin/accounts/buddyicon', '')
+        purple.PurplePrefsSetPath('(ss)', '/pidgin/accounts/buddyicon', '')
         if filename:
-            purple.PurplePrefsSetPath('/pidgin/accounts/buddyicon', filename)
+            purple.PurplePrefsSetPath('(ss)', '/pidgin/accounts/buddyicon', filename)
 
     def set_pidgin_buddyicon_xml(self, filename=None):
         """Set the buddyicon used by pidgin to filename (via the xml file)."""


### PR DESCRIPTION
According to https://www.freedesktop.org/wiki/Software/DBusBindings/ dbus-python is obsolete, recommended binding is GDBus.