### PR TITLE
Add python3.9 compatiblity

### DIFF
--- a/mugshot_lib/Builder.py
+++ b/mugshot_lib/Builder.py
@@ -89,7 +89,7 @@ class Builder(Gtk.Builder):
         tree = ElementTree()
         tree.parse(filename)
 
-        ele_widgets = tree.getiterator("object")
+        ele_widgets = tree.iter("object")
         for ele_widget in ele_widgets:
             name = ele_widget.attrib['id']
             widget = self.get_object(name)
@@ -111,7 +111,7 @@ class Builder(Gtk.Builder):
             if connections:
                 self.connections.extend(connections)
 
-        ele_signals = tree.getiterator("signal")
+        ele_signals = tree.iter("signal")
         for ele_signal in ele_signals:
             self.glade_handler_dict.update(
                 {ele_signal.attrib["handler"]: None})


### PR DESCRIPTION
Starting with python3.9, launching of mugshot will fail,
as getiterator() been deprecated since Python 2.7,
and has been removed in Python 3.9. Using iter() will fix that.

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>